### PR TITLE
PICO VR Teleoperation Retargeting Codebase

### DIFF
--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,0 +1,72 @@
+Hello, thank you for sharing this great codebase.
+I have been using the `retargeting/` package for robot teleoperation in an Isaac Sim environment and would like to share some information that may be helpful :)
+
+---
+
+# PICO VR Teleoperation Support 
+
+A reference example for teleoperating the AI Worker ffw_sh5 model using VR. This code is also applicable to Isaac Sim.
+
+The pipeline follows a two-stage coordinate transformation: VR hand tracking data → 3D hand model frame (MANO convention) → Robot URDF frame. Because the intermediate representation is MANO-compatible, any VR device that outputs hand tracking in MANO convention can be integrated without further changes to the retargeting logic.
+
+## Changes
+
+### 1. Added `examples/teleoperation_mujoco_pico/`
+
+A minimal, self-contained example that uses only the `retargeting` module to teleoperate the HX5-D20 hand in MuJoCo via PICO VR.
+
+| File | Description |
+|---|---|
+| `examples/teleoperation_mujoco_pico/main_control.py` | New |
+| `examples/teleoperation_mujoco_pico/README.md` | Pipeline walkthrough |
+
+### 2. Add `set_pre_calibration()` to `seq_retarget.py`
+
+`teleop_retargeting.py` currently applies `finger_scaling` using the very first hand frame received. Any noise or inaccurate detection in that first frame propagates directly into the scaling and cannot be corrected without restarting. In my XRobotToolkit with PICO VR environment, I observed noticeable variation between runs.
+
+This PR adds a `set_pre_calibration()` method to `seq_retarget.py` that accepts pre-measured finger lengths (`human_lengths: list[float]`) and immediately computes and synchronises `finger_scaling`, bypassing the first-frame auto-calibration.
+
+In `teleop_retargeting.py`, if a `PRE_CALIBRATION` variable (= human finger lengths) is declared and not `None`, that value is used for scaling at startup. If it is `None`, the existing first-frame behaviour is preserved. Please refer to `teleop_retargeting.py`.
+
+This allows a practical two-phase workflow:
+- **First test run** — use first-frame auto-calibration to get started quickly.
+- **Production run** — supply values measured by `wrist_to_tip_calibration.py` to guarantee consistent retargeting across every run.
+
+`wrist_to_tip_calibration.py` is also included. It reads hand joint data from a PICO VR Ultra 4 via XRobotToolkit, accumulates samples while the user holds an open-palm pose, and outputs a ready-to-paste array for `PRE_CALIBRATION` / `set_pre_calibration()`.
+
+| File | Description |
+|---|---|
+| `cyclo_motion_controller_core/src/retargeting/seq_retarget.py` | Added `set_pre_calibration()` |
+| `cyclo_motion_controller_ros_py/scripts/wrist_to_tip_calibration.py` | New |
+
+### 3. Tighten HX5-D20 Thumb Joint Limits
+
+The HX5-D20 hand differs from most widely-used dexterous hands (Allegro, Shadow, LEAP, Inspire, and common anthropomorphic abstractions) in that the order of thumb joints 1 and 2 is reversed.
+
+In my Isaac Sim teleoperation tests, depending on the hand pose at the start of teleoperation, the dex-pilot occasionally returned a solution where the nail-bed and nail positions of the thumb were swapped. This arises because the wide range of `joint_2` (joint_b) (`0` to `3.14` rad) allows multiple valid joint positions, and the solver may converge to an unintended one.
+
+Constraining the range to something more human-like (`0` to `1.57` rad) eliminates the ambiguous solutions while still supporting all common grasp types (GRASP, PINCH, FIST) without any loss of functionality.
+
+In my development environment I enforced this limit in code before passing values downstream, but I have reflected it directly in the URDF here so that it applies universally and confirmed that the hand operates correctly with this change.
+
+* NOTICE: I downloaded [hx5_d20_left.urdf.xacro](https://github.com/ROBOTIS-GIT/robotis_hand/blob/main/robotis_hand_description/urdf/hx5_d20_rev2/hx5_d20_left.urdf.xacro) (also right) and [ffw_sh5.xml](https://github.com/ROBOTIS-GIT/robotis_mujoco_menagerie/blob/main/robotis_ffw/ffw_sh5.xml) from the official repositories and have been applying this correction manually. After checking the repositories again before submitting this PR, I found that the same correction has already been applied upstream. The same correction may also need to be reflected in the linked URDF and XML files. As this is part of my ongoing troubleshooting process, I have kept the proposal as-is and will attach a demonstration video.
+
+| File | Description |
+|---|---|
+| `cyclo_motion_controller_models/models/hx5_d20/hx5_d20_left.urdf` | Thumb `joint_2` limit tightened |
+| `cyclo_motion_controller_models/models/hx5_d20/hx5_d20_right.urdf` | Thumb `joint_2` limit tightened |
+
+### Motivation
+
+The `retargeting` package was designed with portability in mind, and I have been using it together with a CuRobo IK solver (for arm) in both MuJoCo and Isaac Sim environments for remote teleoperation.
+The per-finger scaling approach in the provided hand retargeting code works remarkably well in practice.
+
+By separating the coordinate transformation into two explicit steps — MANO convention → Robot URDF base frame (`_R_MANO_TO_ROBOT`) — swapping the VR device or replacing the robot hand requires updating only one matrix, leaving the rest of the pipeline intact.
+
+---
+
+# Out of Scope
+
+No changes are made to ROS 2 node logic, controller behaviour, or the build system.
+
+I have been running teleoperation in simulation using a CuRobo-based IK solver together with the provided retargeting package in an Isaac Sim environment, and I have ported the parts I thought would be worth sharing back into this repository. :)

--- a/cyclo_motion_controller_core/src/retargeting/seq_retarget.py
+++ b/cyclo_motion_controller_core/src/retargeting/seq_retarget.py
@@ -170,6 +170,19 @@ class ROBOTISHandRetargeter:
         finger_lengths = np.linalg.norm(tip_positions - wrist_pos, axis=1)
         return finger_lengths.astype(np.float32)
 
+    def set_pre_calibration(self, human_lengths: list[float]) -> None:
+        lengths = np.array(human_lengths, dtype=np.float32)
+        if lengths.shape != (5,):
+            raise ValueError(f'human_lengths must have exactly 5 elements, got {len(human_lengths)}')
+        self.finger_scaling = lengths / (self.robot_finger_lengths + 1e-6)
+        self.optimizer.finger_scaling = self.finger_scaling
+        self.optimizer.vector_scaling = self.optimizer.build_vector_scaling()
+        self.is_calibrated = True
+
+        print(f'[Retargeter] Pre-calibrated finger scaling: {self.finger_scaling}')
+        print(f'[Retargeter] Pre-calibration human finger lengths: {lengths}')
+        print('[Retargeter] Robot finger lengths: ' f'{self.robot_finger_lengths}')
+
     def _calibrate_scaling(self, mediapipe_pose: np.ndarray) -> None:
         """Calibrate per-finger scaling from the first observed hand pose."""
         human_lengths = self._compute_human_finger_lengths(mediapipe_pose)

--- a/cyclo_motion_controller_models/models/hx5_d20/hx5_d20_left.urdf
+++ b/cyclo_motion_controller_models/models/hx5_d20/hx5_d20_left.urdf
@@ -33,7 +33,7 @@
       <child link="finger_l_link1" />
       <origin xyz="-0.0125 -0.03493 0.04475" rpy="0 0 0" />
       <axis xyz="1 0 0" />
-      <limit velocity="4.8" effort="1000" lower="-1.57" upper="1.57" />
+      <limit velocity="4.8" effort="1000" lower="-1.57" upper="1.57" /> 
       <dynamics damping="0.05" />
    </joint>
    <link name="finger_l_link1">
@@ -68,7 +68,7 @@
       <child link="finger_l_link2" />
       <origin xyz="0.039 0.0 0.0" rpy="0 0 0" />
       <axis xyz="0 0 1" />
-      <limit velocity="4.8" effort="1000" lower="0.0" upper="1.57" />
+      <limit velocity="4.8" effort="1000" lower="0.0" upper="1.57" /> <!-- upper 3.14 in other repository-->
       <dynamics damping="0.05" />
    </joint>
    <link name="finger_l_link2">

--- a/cyclo_motion_controller_models/models/hx5_d20/hx5_d20_right.urdf
+++ b/cyclo_motion_controller_models/models/hx5_d20/hx5_d20_right.urdf
@@ -68,7 +68,7 @@
       <child link="finger_r_link2" />
       <origin xyz="0.039 0.0 0.0" rpy="0 0 0" />
       <axis xyz="0 0 1" />
-      <limit velocity="4.8" effort="1000" lower="-1.57" upper="0.0" />
+      <limit velocity="4.8" effort="1000" lower="-1.57" upper="0.0" /> <!-- lower -3.14 in other repository-->
       <dynamics damping="0.05" />
    </joint>
    <link name="finger_r_link2">

--- a/cyclo_motion_controller_ros_py/scripts/wrist_to_tip_calibration.py
+++ b/cyclo_motion_controller_ros_py/scripts/wrist_to_tip_calibration.py
@@ -1,0 +1,112 @@
+"""
+Usage:
+    python wrist_to_tip_calibration.py
+    python wrist_to_tip_calibration.py --hand_type left
+Controls:
+    s  - start / stop sampling
+    q  - quit and print the final calibration array
+"""
+
+import os
+import sys
+import threading
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+import numpy as np
+
+from xrobotoolkit_teleop.common.xr_client import XrClient
+from xrobotoolkit_teleop.utils.dex_hand_utils import (build_palm_frame_from_landmarks, pico_hand_state_to_mediapipe,)
+
+MP_WRIST_IDX = 0
+MP_FINGER_TIP_INDICES = [4, 8, 12, 16, 20]
+FINGER_NAMES = ["Thumb", "Index", "Middle", "Ring", "Pinky"]
+
+def _compute_human_finger_lengths(mediapipe_pose: np.ndarray) -> np.ndarray:
+    wrist_pos = mediapipe_pose[MP_WRIST_IDX]
+    tip_positions = mediapipe_pose[MP_FINGER_TIP_INDICES]
+    return np.linalg.norm(tip_positions - wrist_pos, axis=1).astype(np.float32)
+
+def _keyboard_listener(state: dict) -> None:
+    import termios
+    import tty
+
+    fd = sys.stdin.fileno()
+    old_settings = termios.tcgetattr(fd)
+    try:
+        tty.setraw(fd)
+        while not state["quit"]:
+            ch = sys.stdin.read(1)
+            if ch == "s":
+                state["sampling"] = not state["sampling"]
+                label = "STARTED" if state["sampling"] else "PAUSED"
+                print(f"\r[Calibration] Sampling {label}                    ")
+            elif ch == "q":
+                state["quit"] = True
+    finally:
+        termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
+
+
+def main(hand_type: str = "right") -> None:
+    xr_client = XrClient()
+
+    state = {"sampling": False, "quit": False}
+    kb_thread = threading.Thread(target=_keyboard_listener, args=(state,), daemon=True)
+    kb_thread.start()
+
+    print("=" * 60)
+    print("  ROBOTIS Hand Finger-Length Calibration")
+    print("  Press  s  to start/pause sampling")
+    print("  Press  q  to quit and print the result")
+    print("=" * 60)
+
+    accumulated: list[np.ndarray] = [] 
+
+    try:
+        while not state["quit"]:
+            hand_state = xr_client.get_hand_tracking_state(hand_type)
+            if hand_state is None:
+                continue
+            hand_state_np = np.array(hand_state)
+            if hand_state_np.ndim != 2 or hand_state_np.shape[0] < 26:
+                continue
+            try:
+                mediapipe_pose = pico_hand_state_to_mediapipe(hand_state_np)  # (21, 3)
+            except ValueError:
+                continue
+
+            finger_lengths = _compute_human_finger_lengths(mediapipe_pose)  # (5,)
+
+            if state["sampling"]:
+                accumulated.append(finger_lengths)
+                mean_lengths = np.mean(accumulated, axis=0)
+                n = len(accumulated)
+
+                parts = "  ".join(f"{name}={length:.4f}"for name, length in zip(FINGER_NAMES, mean_lengths))
+                print(f"\r[n={n:5d}]  {parts}", end="", flush=True)
+
+    except KeyboardInterrupt:
+        pass
+
+    print()
+
+    if not accumulated:
+        print("[Calibration] No samples collected. Exiting.")
+        return
+
+    final_lengths = np.mean(accumulated, axis=0)
+
+    print()
+    print("=" * 60)
+    print(f"  Samples collected : {len(accumulated)}")
+    print("  Mean finger lengths (wrist → tip, palm-local frame):")
+    for name, length in zip(FINGER_NAMES, final_lengths): print(f"    {name:8s}: {length:.6f} m")
+    print()
+    print("  Copy the line below PRE_CALIBRATION  --human_finger_lengths:")
+    arr_str = ", ".join(f"{v:.6f}" for v in final_lengths)
+    print(f"    [{arr_str}]")
+    print("=" * 60)
+
+if __name__ == "__main__":
+    import tyro
+    tyro.cli(main)

--- a/examples/teleoperation_mujoco_pico/README.md
+++ b/examples/teleoperation_mujoco_pico/README.md
@@ -1,0 +1,127 @@
+# Teleoperation Example — MuJoCo + PICO VR → HX5-D20
+
+This example shows how to use the `retargeting` package from this repository
+in a standalone, ROS-free workspace to teleoperate the HX5-D20 dexterous hand
+inside a MuJoCo simulation using a PICO VR headset.
+
+## Table of Contents
+
+1. [Overview](#overview)
+2. [Configuration](#configuration)
+3. [Running](#running)
+4. [Pipeline Walkthrough](#pipeline-walkthrough)
+
+
+---
+
+## Overview
+
+```
+PICO VR (XrClient)
+      │  raw hand-joint state  (≥26 × 7)
+      ▼
+pico_hand_state_to_mediapipe()        xrobotoolkit_teleop
+      │  MediaPipe landmarks  (21 × 3)  wrist-centred world frame
+      ▼
+_to_palm_local()                      geometric normalisation
+      │  finger positions relative to palm  (MANO convention)
+      ▼
+@ _R_MANO_TO_ROBOT                    robot-specific axis rotation
+      │  landmarks in robot URDF base frame
+      ▼
+ROBOTISHandRetargeter.retarget()      retargeting (this repo)
+      │  robot joint positions  (qpos)
+      ▼
+mj_data.ctrl                          MuJoCo passive viewer
+```
+
+The `retargeting/` package is the **only** dependency on this repository.
+Everything else (MuJoCo, PICO SDK, MuJoCo scene XML) is external.
+
+---
+
+## Configuration
+
+**`PRE_CALIBRATION`**
+
+```python
+PRE_CALIBRATION = [0.122617, 0.169113, 0.180041, 0.164834, 0.145511]
+```
+
+Five wrist-to-fingertip distances in metres, ordered thumb → pinky, measured
+on the operator's hand. These are applied at startup so that the retargeter
+does not rely on a potentially noisy first frame to auto-calibrate finger
+scaling.
+
+**`_R_MANO_TO_ROBOT`**
+
+```python
+_R_MANO_TO_ROBOT = np.array([
+    [ 0,  0, -1],
+    [-1,  0,  0],
+    [ 0,  1,  0],
+], dtype=np.float64)
+```
+
+3 × 3 rotation matrix mapping MANO palm-local axes to the HX5-D20 URDF base
+frame. If you target a different robot hand, this is the only matrix to
+update. See [Pipeline Walkthrough](#pipeline-walkthrough) for the axis
+conventions.
+
+---
+
+## Running
+
+```bash
+cd examples/teleoperation_mujoco_pico
+
+# Default paths
+python main_control.py
+
+# Custom paths
+python main_control.py \
+  --xml-path /path/to/scene.xml \
+  --urdf-path /path/to/hx5_d20_right.urdf \
+  --hand-type right
+```
+```bash
+python main_control.py --help
+```
+
+---
+
+## Pipeline Walkthrough
+
+### Step 1 — PICO → MediaPipe
+
+`pico_hand_state_to_mediapipe()` converts the PICO-native joint state (≥26 × 7)
+into the 21-landmark MediaPipe layout in the wrist-centred world frame.
+All PICO-specific encoding is removed here; the rest of the pipeline is
+input-device agnostic.
+
+### Step 2 — Palm-local normalisation (`_to_palm_local`)
+
+`build_palm_frame_from_landmarks()` constructs an orthonormal frame from the
+palm landmarks and `mediapipe_pose @ palm_frame` expresses every landmark
+relative to that frame (MANO convention).
+
+This step separates two concerns that are often conflated:
+
+- **Geometric normalisation** — finger positions become relative to the palm,
+  independent of wrist position and world orientation.
+- **Robot-axis alignment** — done separately in step 3.
+
+Keeping them separate means that adapting to a different robot hand only
+requires updating `_R_MANO_TO_ROBOT`; the normalisation logic is unchanged.
+
+### Step 3 — MANO → Robot URDF frame
+`mediapipe_local @ _R_MANO_TO_ROBOT` rotates the normalised landmarks into the
+coordinate frame expected by the URDF and `ROBOTISHandRetargeter`.
+
+### Step 4 — Retargeting and actuation
+
+`retarget()` solves for robot joint positions that
+reproduce the observed finger configuration. The resulting `qpos` vector is
+written into `mj_data.ctrl` via the actuator index map built by
+`build_qpos_to_actuator_map()`.
+---

--- a/examples/teleoperation_mujoco_pico/main_control.py
+++ b/examples/teleoperation_mujoco_pico/main_control.py
@@ -1,0 +1,126 @@
+import os
+import sys
+
+# Make the local `retargeting` package importable
+sys.path.insert(0, os.path.dirname(__file__))
+
+import mujoco
+import numpy as np
+import tyro
+from mujoco import viewer as mj_viewer
+
+from retargeting.seq_retarget import ROBOTISHandRetargeter
+from xrobotoolkit_teleop.common.xr_client import XrClient
+from xrobotoolkit_teleop.utils.dex_hand_utils import (
+    build_palm_frame_from_landmarks,
+    pico_hand_state_to_mediapipe,
+)
+
+# ===== MANO convention → Robot URDF base frame =====
+#   MANO:  X = backward,  Y = dorsal,  Z = radial
+#   Robot: X = palmar,    Y = radial,  Z = forward
+#
+#   Robot_X = -MANO_Y  (palmar = opposite of dorsal)
+#   Robot_Y =  MANO_Z  (radial = same)
+#   Robot_Z = -MANO_X  (forward = opposite of backward)
+#
+#   M[i,j] = how much MANO component i contributes to Robot component j
+#   row 0 (MANO_X=backward):  → -Robot_Z (forward)
+#   row 1 (MANO_Y=dorsal):    → -Robot_X (palmar)
+#   row 2 (MANO_Z=radial):    →  Robot_Y (radial)
+
+_R_MANO_TO_ROBOT = np.array([
+    [ 0,  0, -1],
+    [-1,  0,  0],
+    [ 0,  1,  0],
+], dtype=np.float64)
+
+PRE_CALIBRATION = [0.122617, 0.169113, 0.180041, 0.164834, 0.145511]
+
+# ===== Coordinate transform =====
+
+def _to_palm_local(mediapipe_pose: np.ndarray, hand_side: str = "right",) -> tuple[np.ndarray, np.ndarray]:
+    palm_frame = build_palm_frame_from_landmarks(mediapipe_pose, hand_side=hand_side)
+    return mediapipe_pose @ palm_frame, palm_frame
+
+# ===== Actuator mapping =====
+
+def build_qpos_to_actuator_map(mj_model, dof_joint_names: list[str]) -> dict[int, int]:
+    """Map retargeter qpos indices to MuJoCo actuator IDs."""
+    mapping: dict[int, int] = {}
+    for qpos_idx, joint_name in enumerate(dof_joint_names):
+        act_id = mujoco.mj_name2id(mj_model, mujoco.mjtObj.mjOBJ_ACTUATOR, joint_name)
+        if act_id >= 0:
+            mapping[qpos_idx] = act_id
+        else:
+            print(f"[Warning] Joint '{joint_name}' has no matching actuator in the MuJoCo model.")
+    return mapping
+
+
+def main(
+    xml_path: str = os.path.join(os.path.dirname(__file__), "../robotis_ffw/scene_ffw_sh5.xml"),
+    urdf_path: str = os.path.join(os.path.dirname(__file__), "../hx5_d20_right.urdf"),
+    hand_type: str = "right",
+):
+
+    # ===== MuJoCo model ===== 
+    mj_model = mujoco.MjModel.from_xml_path(xml_path)
+    mj_data = mujoco.MjData(mj_model)
+
+    # ===== Retargeter =====
+    retargeter = ROBOTISHandRetargeter(path_to_urdf=urdf_path, hand_side=hand_type)
+    print(f"[Retargeter] DOF joint names: {retargeter.robot.dof_joint_names}")
+
+    retargeter.set_pre_calibration(PRE_CALIBRATION)
+
+    qpos_to_actuator = build_qpos_to_actuator_map(mj_model, retargeter.robot.dof_joint_names)
+    print(f"[Retargeter] Mapped {len(qpos_to_actuator)} joints to actuators.")
+    dof_names = retargeter.robot.dof_joint_names
+    for qpos_idx, act_id in qpos_to_actuator.items():
+        print(f"  qpos[{qpos_idx:2d}] {dof_names[qpos_idx]:20s} (act_id={act_id})")
+
+    # ===== XR client =====
+    xr_client = XrClient()
+
+    # ===== Main loop =====
+    with mj_viewer.launch_passive(mj_model, mj_data) as viewer:
+        viewer.cam.azimuth  = 180
+        viewer.cam.elevation = -20
+        viewer.cam.distance  = 1.5
+        viewer.cam.lookat    = [0.0, 0.0, 0.5]
+
+        while viewer.is_running():
+            # 1. Receive PICO data to MediaPipe (21, 3) wrist-centred world frame
+            hand_state = xr_client.get_hand_tracking_state(hand_type)
+            if hand_state is not None:
+                hand_state_np = np.array(hand_state)   # expected (27, 7)
+
+                if hand_state_np.ndim == 2 and hand_state_np.shape[0] >= 26:
+                    try:
+                        mediapipe_pose = pico_hand_state_to_mediapipe(hand_state_np)  # (21, 3)
+                        # NOTE: 2. Convert to canonical palm-local frame (MANO convention)
+                        #    This separates two concerns: geometric normalisation (making finger
+                        #    positions relative to the palm, independent of wrist position and world
+                        #    orientation) and robot-axis alignment.  The robot-specific part is
+                        #    isolated to the single matrix _R_MANO_TO_ROBOT in step 3, so adapting
+                        #    to a different robot hand only requires updating that matrix.
+                        mediapipe_local, _ = _to_palm_local(mediapipe_pose, hand_side=hand_type)
+
+                        # 3. Transform from MANO convention to robot URDF frame,
+                        #    then retarget to robot joint positions.
+                        robot_local = mediapipe_local @ _R_MANO_TO_ROBOT
+                        result = retargeter.retarget(robot_local)
+
+                        # 4. Write robot_qpos into mj_data.ctrl.
+                        for qpos_idx, act_id in qpos_to_actuator.items():
+                            mj_data.ctrl[act_id] = result.robot_qpos[qpos_idx]
+
+                    except ValueError as e:
+                        print(f"[Warning] Retargeting skipped: {e}")
+
+            mujoco.mj_step(mj_model, mj_data)
+            viewer.sync()
+
+
+if __name__ == "__main__":
+    tyro.cli(main)


### PR DESCRIPTION
Hello, thank you for sharing this great codebase.

I am Bosung Kwon, a Mechanical Engineering student (Class of 2021) at KAIST. I am currently conducting research on teleoperation data collection at the KIST AI Research Center under the supervision of Dr. Hwaseop Lim (Head of the AI Research Center) and Dr. Taekun Yoo.

I have been using the `retargeting/` package for robot teleoperation in an Isaac Sim environment and would like to share some information that may be helpful :)
<img alt="Screenshot from 2026-04-09 11-19-01" src="https://github.com/user-attachments/assets/d33093f3-bab1-451e-822e-6af3dbfe985d" style="max-width: 100%; height: auto;" />

---

# PICO VR Teleoperation Support 

A reference for teleoperating the AI Worker ffw_sh5 model using VR. This code is also applicable to Isaac Sim.
<img alt="Screencast from 04-09-2026 01_09_37 PM" src="https://github.com/user-attachments/assets/e0a59dee-74dc-4994-bf9c-fb9c04a3a22a" style="max-width: 100%; height: auto;" />

The pipeline follows a two-stage coordinate transformation
```
VR hand tracking data
        │
        ▼  Stage 1: Device-specific → MANO 3D hand model frame
MANO convention (device-agnostic)
        │
        ▼  Stage 2: MANO → Robot URDF base frame  (_R_MANO_TO_ROBOT)
Robot joint positions
```
Because the intermediate representation is MANO-compatible, any VR device that can output hand tracking in MANO convention can be integrated without further changes to the retargeting logic.

## Changes

### 1. Added `examples/teleoperation_mujoco_pico/`

A minimal, self-contained example that uses only the `retargeting` module to teleoperate HX5-D20 hand in MuJoCo via PICO VR.

| File | Description |
|---|---|
| `examples/teleoperation_mujoco_pico/main_control.py` | New |
| `examples/teleoperation_mujoco_pico/README.md` | Pipeline walkthrough |

### 2. Add `set_pre_calibration()` to `seq_retarget.py`

`teleop_retargeting.py` currently applies `finger_scaling` using the very first hand frame received. Any noise or inaccurate detection in that first frame propagates directly into the scaling and cannot be corrected without restarting. In my XRobotToolkit with PICO VR environment, I observed noticeable variation between runs.

This PR adds a `set_pre_calibration()` method to `seq_retarget.py` that accepts pre-measured finger lengths (`human_lengths: list[float]`) and immediately computes and synchronises `finger_scaling`, bypassing the first-frame auto-calibration.

In `teleop_retargeting.py`, if a `PRE_CALIBRATION` variable (= human finger lengths) is declared and not `None`, that value is used for scaling at startup. If it is `None`, the existing first-frame behaviour is preserved. Please refer to `teleop_retargeting.py`.

This allows a practical two-phase workflow:
- **First test run** — use first-frame auto-calibration to get started quickly.
- **Production run** — supply values measured by `wrist_to_tip_calibration.py` to guarantee consistent retargeting across every run.

`wrist_to_tip_calibration.py` is also included. It reads hand joint data from a PICO VR Ultra 4 via XRobotToolkit, accumulates samples while the user holds an open-palm pose, and outputs a ready-to-paste array for `PRE_CALIBRATION` / `set_pre_calibration()`.

| File | Description |
|---|---|
| `cyclo_motion_controller_core/src/retargeting/seq_retarget.py` | Added `set_pre_calibration()` |
| `cyclo_motion_controller_ros_py/scripts/wrist_to_tip_calibration.py` | New |

### 3. Tighten HX5-D20 Thumb Joint Limits

The HX5-D20 hand differs from most widely-used dexterous hands (Allegro, Shadow, LEAP, Inspire, and common anthropomorphic abstractions) in that the order of thumb joints 1 and 2 is reversed.

In my Isaac Sim teleoperation tests, depending on the hand pose at the start of teleoperation, the dex-pilot occasionally returned a solution where the nail-bed and nail positions of the thumb were swapped. This arises because the wide range of `joint_2` (joint_b) (`0` to `3.14` rad) allows multiple valid joint positions, and the solver may converge to an unintended one.

Constraining the range to something more human-like (`0` to `1.57` rad) eliminates the ambiguous solutions while still supporting all common grasp types (GRASP, PINCH, FIST) without any loss of functionality.

In my development environment I enforced this limit in code before passing values downstream, but I have reflected it directly in the URDF here so that it applies universally and confirmed that the hand operates correctly with this change.

* NOTICE: I downloaded [hx5_d20_left.urdf.xacro](https://github.com/ROBOTIS-GIT/robotis_hand/blob/main/robotis_hand_description/urdf/hx5_d20_rev2/hx5_d20_left.urdf.xacro) (also right) and [ffw_sh5.xml](https://github.com/ROBOTIS-GIT/robotis_mujoco_menagerie/blob/main/robotis_ffw/ffw_sh5.xml) from the official repositories and have been applying this correction manually. After checking the repositories again before submitting this PR, I found that the same correction has already been applied upstream. The same correction may also need to be reflected in the linked URDF and XML files. As this is part of my ongoing troubleshooting process, I have kept the proposal as-is and will attach a demonstration video.
<img alt="Screencast from 04-09-2026 11_26_22 AM" src="https://github.com/user-attachments/assets/748bcec2-e9ae-4cbe-926f-05611af8639d" style="max-width: 100%; height: auto;" />

[After fixing joint_2 limit]

<img alt="Screencast from 04-09-2026 11_40_15 AM" src="https://github.com/user-attachments/assets/52041b0e-8577-486d-96cf-78b3ef0a2257" style="max-width: 100%; height: auto;" />

[Before fixing joint_2 limit]

| File | Description |
|---|---|
| `cyclo_motion_controller_models/models/hx5_d20/hx5_d20_left.urdf` | Thumb `joint_2` limit tightened |
| `cyclo_motion_controller_models/models/hx5_d20/hx5_d20_right.urdf` | Thumb `joint_2` limit tightened |

### Motivation

The `retargeting` package was designed with portability in mind, and I have been using it together with a CuRobo IK solver (for arm) in both MuJoCo and Isaac Sim environments for remote teleoperation.
The per-finger scaling approach in the provided hand retargeting code works remarkably well in practice.

By separating the coordinate transformation into two explicit steps — MANO convention → Robot URDF base frame (`_R_MANO_TO_ROBOT`) — swapping the VR device or replacing the robot hand requires updating only one matrix, leaving the rest of the pipeline intact.

---

# Out of Scope

No changes are made to ROS 2 node logic, controller behaviour, or the build system.

I have been running teleoperation in simulation using a CuRobo-based IK solver together with the provided retargeting package in an Isaac Sim environment, and I have ported the parts I thought would be worth sharing back into this repository. :)

